### PR TITLE
Plugin refactoring

### DIFF
--- a/Plugins/ConsolePlugin/Source/ConsolePlugin/Private/Cartridge.cpp
+++ b/Plugins/ConsolePlugin/Source/ConsolePlugin/Private/Cartridge.cpp
@@ -7,19 +7,14 @@
 
 #include "Terminal.h"
 
-void UCartridge::OnInput(const FString& input)
-{
-
-}
-
-void UCartridge::PrintLine(const FString& line)
+void UCartridge::PrintLine(const FString& Line) const
 {
     auto Terminal = GetOwner()->FindComponentByClass<UTerminal>();
     if (Terminal == nullptr) return;
-    Terminal->PrintLine(line);
+    Terminal->PrintLine(Line);
 }
 
-void UCartridge::ClearScreen()
+void UCartridge::ClearScreen() const
 {
     auto Terminal = GetOwner()->FindComponentByClass<UTerminal>();
     if (Terminal == nullptr) return;

--- a/Plugins/ConsolePlugin/Source/ConsolePlugin/Private/Terminal.cpp
+++ b/Plugins/ConsolePlugin/Source/ConsolePlugin/Private/Terminal.cpp
@@ -8,7 +8,7 @@
 
 #include "Cartridge.h"
 
-const FString PROMPT = TEXT("$> ");
+constexpr TCHAR* GPrompt = TEXT("$> ");
 
 // Called when the game starts
 void UTerminal::BeginPlay()
@@ -31,7 +31,7 @@ void UTerminal::ActivateTerminal()
     RepeatBindingIndex = GetOwner()->InputComponent->KeyBindings.Emplace(MoveTemp(RepeatBinding));
 }
 
-void UTerminal::DeactivateTerminal()
+void UTerminal::DeactivateTerminal() const
 {
 	if (GetOwner()->InputComponent == nullptr) return;
 	
@@ -53,7 +53,7 @@ void UTerminal::ClearScreen()
 FString UTerminal::GetScreenText() const
 {
 	TArray<FString> FullTerminal = Buffer;
-	FullTerminal.Add(PROMPT + InputLine);
+	FullTerminal.Add(GPrompt + InputLine);
 
 	// WrapLines
 	TArray<FString> WrappedLines(WrapLines(FullTerminal));
@@ -107,8 +107,8 @@ void UTerminal::OnKeyDown(FKey Key)
 		Backspace();
 	}
 
-	FString KeyString = GetKeyString(Key);
-	FModifierKeysState KeyState = FSlateApplication::Get().GetModifierKeys();
+    const FString KeyString = GetKeyString(Key);
+    const FModifierKeysState KeyState = FSlateApplication::Get().GetModifierKeys();
 	if (KeyState.IsShiftDown() || KeyState.AreCapsLocked())
 	{
 		InputLine += KeyString.ToUpper();
@@ -124,11 +124,11 @@ void UTerminal::OnKeyDown(FKey Key)
 
 void UTerminal::AcceptInputLine()
 {
-	Buffer.Emplace(PROMPT + InputLine);
-	auto cartridge = GetOwner()->FindComponentByClass<UCartridge>();
-	if (cartridge != nullptr)
+	Buffer.Emplace(GPrompt + InputLine);
+	auto Cartridge = GetOwner()->FindComponentByClass<UCartridge>();
+	if (Cartridge != nullptr)
 	{
-		cartridge->OnInput(InputLine);
+		Cartridge->OnInput(InputLine);
 	}
 	InputLine = TEXT("");
 

--- a/Plugins/ConsolePlugin/Source/ConsolePlugin/Public/Cartridge.h
+++ b/Plugins/ConsolePlugin/Source/ConsolePlugin/Public/Cartridge.h
@@ -12,12 +12,12 @@ class CONSOLEPLUGIN_API UCartridge : public UActorComponent
 {
 	GENERATED_BODY()
 
-public:	
-	virtual void OnInput(const FString& input);
+public:
+    virtual void OnInput(const FString& Input) PURE_VIRTUAL(UCartridge::OnInput,);
 
 
 protected:
-	void PrintLine(const FString& line);
-	void ClearScreen();
+	void PrintLine(const FString& Line) const;
+	void ClearScreen() const;
 
 };

--- a/Plugins/ConsolePlugin/Source/ConsolePlugin/Public/Cartridge.h
+++ b/Plugins/ConsolePlugin/Source/ConsolePlugin/Public/Cartridge.h
@@ -18,6 +18,11 @@ public:
 
 protected:
 	void PrintLine(const FString& Line) const;
+    template<typename ...Types>
+    void PrintLine(const TCHAR* Fmt, Types... Args) const
+    {
+        PrintLine(FString::Printf(Fmt, Args...));
+    }
 	void ClearScreen() const;
 
 };

--- a/Plugins/ConsolePlugin/Source/ConsolePlugin/Public/IConsolePlugin.h
+++ b/Plugins/ConsolePlugin/Source/ConsolePlugin/Public/IConsolePlugin.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Modules/ModuleInterface.h"
 #include "Modules/ModuleManager.h"
 

--- a/Plugins/ConsolePlugin/Source/ConsolePlugin/Public/Terminal.h
+++ b/Plugins/ConsolePlugin/Source/ConsolePlugin/Public/Terminal.h
@@ -5,7 +5,6 @@
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
 #include "GameFramework/Actor.h"
-#include "UObject/ObjectMacros.h"
 #include "Terminal.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FTextUpdateSignature, FString, Text);
@@ -28,9 +27,9 @@ public:
 	void ActivateTerminal();
 
 	UFUNCTION(BlueprintCallable)
-	void DeactivateTerminal();
+	void DeactivateTerminal() const;
 
-	void PrintLine(const FString& line);
+	void PrintLine(const FString& Line);
 	void ClearScreen();
 
 protected:
@@ -38,7 +37,7 @@ protected:
 	virtual void BeginPlay() override;
 
 private:
-	void OnKeyDown(FKey key);
+	void OnKeyDown(FKey Key);
 	TArray<FString> WrapLines(const TArray<FString>&  Lines) const;
 	void Truncate(TArray<FString>& Lines) const;
 	FString JoinWithNewline(const TArray<FString>& Lines) const;


### PR DESCRIPTION
There's tabs and spaces inconsistency present in the plugin source btw. Not sure which one you want to use. You can use VS Code to change them per file.

I opted not to create a `OnInput const` overload as that may lead people to think they can just add const to a virtual function that doesn't have a const overload...OTOH using `override` would warn about that so not sure.

OTOOH You could just introduce const member functions when you change OnInput to longer be able to be const and should avoid that problem all together.